### PR TITLE
fix: change plugin_dir to plugin_lib, fixing crash

### DIFF
--- a/plugin.lua
+++ b/plugin.lua
@@ -63,7 +63,7 @@ local api = {
         ---@type fun(path: string, content: string): boolean
         file_set_content = plugin_lib.fs.file_set_content,
         ---@type fun(path: string): boolean
-        remove_file = plugin_dir.fs.remove_file,
+        remove_file = plugin_lib.fs.remove_file,
         ---@type fun(path: string, target: string): boolean
         move_file = plugin_lib.fs.move_file,
         ---@type fun(path: string, target: string): boolean


### PR DESCRIPTION
The CLI crashes when initializing plugins because "plugin_dir" doesn't exist anymore. I think line 66 was supposed to have "plugin_lib" instead, and seems to work fine with it.

@mrxiaozhuox - can you check and merge this please?