### PR TITLE
feat: expose plugin_dir() function to plugins

### DIFF
--- a/plugin.lua
+++ b/plugin.lua
@@ -94,6 +94,8 @@ local api = {
     dirs = {
         ---@type fun(): string
         crate_dir = plugin_lib.dirs.crate_dir,
+        ---@type fun(): string
+        plugin_dir = plugin_lib.dirs.plugin_dir,
     },
     tool = {
         ---@type fun(object: any): string


### PR DESCRIPTION
For the Tailwind plugin I have two default config files I'd like to copy to the project directory if needed. I see we have a plugin_dir() function that provides the path to the plugin directory, but it wasn't available to plugins. I exposed it to them so I can easily work with files in the plugin folder.