### PR TITLE
fix: give plugins access to config API & add `before_rebuild` event

### DIFF
--- a/manager.lua
+++ b/manager.lua
@@ -33,10 +33,12 @@ local manager = {
 
     ---@class ServeEvent
     ---@field on_start fun(info: ServeStartInfo) | nil
+    ---@field before_rebuild fun(info: ServeRebuildInfo) | nil
     ---@field on_rebuild fun(info: ServeRebuildInfo) | nil
     ---@field on_shutdown function | nil
     serve = {
         on_start = nil,
+        before_rebuild = nil,
         on_rebuild = nil,
         on_shutdown = nil,
     }

--- a/plugin.lua
+++ b/plugin.lua
@@ -127,7 +127,7 @@ do
 
     ---@return DioxusConfig
     function api.config.dioxus_toml()
-        return config_info
+        return plugin_config
     end
 
     ---@return table|nil

--- a/typedef.lua
+++ b/typedef.lua
@@ -39,15 +39,15 @@
 ---@field base_path string | nil
 
 ---@class WebWatcherConfig
----@field watch_path <string>[]
+---@field watch_path string[]
 ---@field reload_html boolean | nil
 ---@field index_on_404 boolean | nil
 
 ---@class WebResourceConfig
 ---@field dev WebDevResourceConfig
----@field style <string>[]
----@field script <string>[]
+---@field style string[]
+---@field script string[]
 
 ---@class WebDevResourceConfig
----@field style <string>[]
----@field script <string>[]
+---@field style string[]
+---@field script string[]


### PR DESCRIPTION
Currently the config API isn't accessible to plugins because the variable `config_info` in plugin.lua, line 130, isn't defined. I think `plugin_config` was supposed to be there, which does make the config accessible to plugins.

I also updated typedef.lua so the config fields had correct type definitions (mostly a cosmetic change to make VS Code's Lua extension shut up because it didn't recognize those variables).

EDIT: Also this is adding a `before_rebuild` event, tied to mrxiaozhuox/dioxus-cli#4.