### PR TITLE
refactor: rename rebuild events

### DIFF
--- a/manager.lua
+++ b/manager.lua
@@ -33,13 +33,13 @@ local manager = {
 
     ---@class ServeEvent
     ---@field on_start fun(info: ServeStartInfo) | nil
-    ---@field before_rebuild fun(info: ServeRebuildInfo) | nil
-    ---@field on_rebuild fun(info: ServeRebuildInfo) | nil
+    ---@field on_rebuild_start fun(info: ServeRebuildInfo) | nil
+    ---@field on_rebuild_end fun(info: ServeRebuildInfo) | nil
     ---@field on_shutdown function | nil
     serve = {
         on_start = nil,
-        before_rebuild = nil,
-        on_rebuild = nil,
+        on_rebuild_start = nil,
+        on_rebuild_end = nil,
         on_shutdown = nil,
     }
 


### PR DESCRIPTION
`before_rebuild` takes place before the rebuild, so it becomes `on_rebuild_start`
`on_rebuild` actually takes place after the rebuild so we should call it `on_rebuild_end`